### PR TITLE
Support for branches in SonarQube projects

### DIFF
--- a/SqCopyResolution/App.config
+++ b/SqCopyResolution/App.config
@@ -9,8 +9,12 @@
     <add key="SQ_Password" value=""/>
     <!-- Key of the project from which are resolutions copied. -->
     <add key="SQ_SourceProjectKey" value=""/>
+    <!-- Name of the branch from which are resolutions copied. -->
+    <add key="SQ_SourceBranch" value=""/>
     <!-- Comma-delimited list of destination projekt keys -->
     <add key="SQ_DestinationProjectKeys" value=""/>
+    <!-- Name of the branch in the destination projects -->
+    <add key="SQ_DestinationBranch" value=""/>
     <!-- Default log level (All, Debug, Info, Warn, Error) -->
     <add key="SQ_LogLevel" value="Info"/>
   </appSettings>

--- a/SqCopyResolution/Model/ConfigurationParameters.cs
+++ b/SqCopyResolution/Model/ConfigurationParameters.cs
@@ -11,8 +11,10 @@ namespace SqCopyResolution.Model
         public string UserName { get; set; }
         public string Password { get; set; }
         public string SourceProjectKey { get; set; }
+        public string SourceBranch { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This is just for passing list of destination project keys to the applicaton.")]
         public string[] DestinationProjectKeys { get; set; }
+        public string DestinationBranch { get; set; }
         public LogLevel LogLevel { get; set; }
 
         public ConfigurationParameters(ILogger logger, string[] commandLineArguments)
@@ -23,7 +25,9 @@ namespace SqCopyResolution.Model
             UserName = ConfigurationManager.AppSettings["SQ_UserName"];
             Password = ConfigurationManager.AppSettings["SQ_Password"];
             SourceProjectKey = ConfigurationManager.AppSettings["SQ_SourceProjectKey"];
+            SourceBranch = ConfigurationManager.AppSettings["SQ_SourceBranch"];
             DestinationProjectKeys = ConfigurationManager.AppSettings["SQ_DestinationProjectKeys"].Split(',');
+            DestinationBranch = ConfigurationManager.AppSettings["SQ_DestinationBranch"];
             LogLevel logLevel;
             if (Enum.TryParse<LogLevel>(ConfigurationManager.AppSettings["SQ_LogLevel"], true, out logLevel))
             {
@@ -57,8 +61,16 @@ namespace SqCopyResolution.Model
                             SourceProjectKey = commandLineArguments[argsIndex + 1].Trim();
                             argsIndex += 2;
                             break;
+                        case "-SOURCEBRANCH":
+                            SourceBranch = commandLineArguments[argsIndex + 1].Trim();
+                            argsIndex += 2;
+                            break;
                         case "-DESTINATIONPROJECTKEYS":
                             DestinationProjectKeys = commandLineArguments[argsIndex + 1].Trim().Split(',');
+                            argsIndex += 2;
+                            break;
+                        case "-DESTINATIONBRANCH":
+                            DestinationBranch = commandLineArguments[argsIndex + 1].Trim();
                             argsIndex += 2;
                             break;
                         case "-LOGLEVEL":

--- a/SqCopyResolution/Program.cs
+++ b/SqCopyResolution/Program.cs
@@ -31,7 +31,7 @@ namespace SqCopyResolutionr
             var sqProxy = new SonarQubeProxy(logger, configParams.SonarQubeUrl, configParams.UserName, configParams.Password);
 
             logger.LogInfo("Getting list of issues for project {0}", configParams.SourceProjectKey);
-            var sourceIssues = sqProxy.GetIssuesForProject(configParams.SourceProjectKey, true);
+            var sourceIssues = sqProxy.GetIssuesForProject(configParams.SourceProjectKey, configParams.SourceBranch, true);
 
             if (sourceIssues.Count > 0)
             {
@@ -39,7 +39,7 @@ namespace SqCopyResolutionr
                 {
                     logger.LogInfo("Copying resolutions to project {0}", destinationProjectKey);
 
-                    var destinationIssues = sqProxy.GetIssuesForProject(destinationProjectKey, false);
+                    var destinationIssues = sqProxy.GetIssuesForProject(destinationProjectKey, configParams.DestinationBranch, false);
                     foreach (var sourceIssue in sourceIssues)
                     {
                         if ((string.CompareOrdinal(sourceIssue.Resolution, "FALSE-POSITIVE") != 0) || (string.CompareOrdinal(sourceIssue.Resolution, "WONTFIX") != 0))


### PR DESCRIPTION
Added support for SonarQube with branches. It is now possible to copy issue resolutions between branches (or between different projects as usual). Specify the source and destination branches in the configuration file or using `-sourceBranch` and `-destinationBranch`.