### PR TITLE
Support for adding comments about the copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Download the **SqCopyResolution_1_0_0.zip** file from the [**Releases**](https:/
 |`-password`|SonarQube credentials - password|
 |`-sourceProjectKey`|Key of the SonarQube project, from which you want to copy resolution flags, e.g. `-sourceProjectKey OurProject:FeatureA`|
 |`-destinationProjectKeys`|Comma separated list of keys of the SonarQube projects, to which you want to copy resolution flags, e.g. `-destinationProjectKeys OurProject:HEAD,OurProject:FeatureB`|
+|`-sourceBranch` (optional)|Name of the branch from which you want to copy resolution flags, e.g. `-sourceBranch develop`. Specify only if you are using SonarQube branches.|
+|`-destinationBranch` (optional)|Name of the branch to which you want to copy resolution flags, e.g. `-destinationBranch master`. Specify only if you are using SonarQube branches.|
+|`-addNote` (optional)|Request that a comment should be added to the destination issue, mentioning the resolution has been copied from elsewhere, e.g. `-addNote` (no parameters).|
 |`-logLevel` (optional)|Log level (All, Debug, Info, Warn, Error), e.g. `-logLevel Debug`. The default log level is Info.|
+|`-dryRun` (optional)|Dry run only, do not do any modifications, just log what would be done, e.g. `-dryRun` (no parameters).|
 
 Here is an example of the command, which copies resolution flags from the `OurProject:FeatureA` to `OurProject:HEAD` and `OurProject:FeatureB` SonarQube projects:
 ```

--- a/SqCopyResolution/App.config
+++ b/SqCopyResolution/App.config
@@ -11,10 +11,12 @@
     <add key="SQ_SourceProjectKey" value=""/>
     <!-- Name of the branch from which are resolutions copied. -->
     <add key="SQ_SourceBranch" value=""/>
-    <!-- Comma-delimited list of destination projekt keys -->
+    <!-- Comma-delimited list of destination project keys -->
     <add key="SQ_DestinationProjectKeys" value=""/>
     <!-- Name of the branch in the destination projects -->
     <add key="SQ_DestinationBranch" value=""/>
+    <!-- Should a comment mentioning the copy be added to the destination? -->
+    <add key="SQ_AddNote" value="false"/>
     <!-- Default log level (All, Debug, Info, Warn, Error) -->
     <add key="SQ_LogLevel" value="Info"/>
   </appSettings>

--- a/SqCopyResolution/Model/ConfigurationParameters.cs
+++ b/SqCopyResolution/Model/ConfigurationParameters.cs
@@ -16,6 +16,7 @@ namespace SqCopyResolution.Model
         public string[] DestinationProjectKeys { get; set; }
         public string DestinationBranch { get; set; }
         public LogLevel LogLevel { get; set; }
+        public bool AddNote { get; set; }
         public bool DryRun { get; set; }
 
         public ConfigurationParameters(ILogger logger, string[] commandLineArguments)
@@ -29,6 +30,10 @@ namespace SqCopyResolution.Model
             SourceBranch = ConfigurationManager.AppSettings["SQ_SourceBranch"];
             DestinationProjectKeys = ConfigurationManager.AppSettings["SQ_DestinationProjectKeys"].Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries);
             DestinationBranch = ConfigurationManager.AppSettings["SQ_DestinationBranch"];
+            if (string.Equals(ConfigurationManager.AppSettings["SQ_AddNote"], "true", StringComparison.OrdinalIgnoreCase))
+            {
+                AddNote = true;
+            }
             LogLevel logLevel;
             if (Enum.TryParse<LogLevel>(ConfigurationManager.AppSettings["SQ_LogLevel"], true, out logLevel))
             {
@@ -84,6 +89,10 @@ namespace SqCopyResolution.Model
                                 Console.WriteLine("Unknown log level: {0}", commandLineArguments[argsIndex + 1]);
                             }
                             argsIndex += 2;
+                            break;
+                        case "-ADDNOTE":
+                            AddNote = true;
+                            argsIndex++;
                             break;
                         case "-DRYRUN":
                             DryRun = true;

--- a/SqCopyResolution/Program.cs
+++ b/SqCopyResolution/Program.cs
@@ -35,6 +35,18 @@ namespace SqCopyResolutionr
 
             if (sourceIssues.Count > 0)
             {
+                string noteToAdd;
+                if (configParams.AddNote)
+                {
+                    noteToAdd = string.IsNullOrEmpty(configParams.SourceBranch)
+                        ? string.Format(CultureInfo.InvariantCulture, "(copy from {0})", configParams.SourceProjectKey)
+                        : string.Format(CultureInfo.InvariantCulture, "(copy from {0}, branch {1})", configParams.SourceProjectKey, configParams.SourceBranch);
+                    logger.LogDebug("Will be adding a note '{0}'", noteToAdd);
+                }
+                else
+                {
+                    noteToAdd = null;
+                }
                 foreach (var destinationProjectKey in configParams.DestinationProjectKeys)
                 {
                     logger.LogInfo("Copying resolutions to project {0}", destinationProjectKey);
@@ -68,7 +80,7 @@ namespace SqCopyResolutionr
                                     sourceIssue.Resolution);
                                 if (!configParams.DryRun)
                                 {
-                                    sqProxy.UpdateIssueResolution(destinationIssue.Key, sourceIssue.Resolution, sourceIssue.Comments);
+                                    sqProxy.UpdateIssueResolution(destinationIssue.Key, sourceIssue.Resolution, sourceIssue.Comments, noteToAdd);
                                 }
                             }
                         }

--- a/SqCopyResolution/Services/SonarQubeProxy.cs
+++ b/SqCopyResolution/Services/SonarQubeProxy.cs
@@ -91,7 +91,7 @@ namespace SqCopyResolution.Services
 
         private int GetNumberOfIssuesForProject(string projectKey, string branchName, bool onlyFalsePositivesAndWontFixes)
         {
-            Logger.LogDebug("Getting number of issues for project {0} (branch {1})", projectKey, branchName);
+            Logger.LogDebug("Getting number of issues for project {0} (branch '{1}')", projectKey, branchName);
 
             var uri = new Uri(string.Format(CultureInfo.InvariantCulture,
                 "{0}/api/issues/search?projectKeys={1}&p=1&ps=1{2}{3}",
@@ -152,7 +152,7 @@ namespace SqCopyResolution.Services
             return result;
         }
 
-        public void UpdateIssueResolution(string issueKey, string newResolution, Comment[] comments)
+        public void UpdateIssueResolution(string issueKey, string newResolution, Comment[] comments, string noteToAdd)
         {
             if (newResolution == null) { throw new ArgumentNullException("newResolution"); }
 
@@ -184,15 +184,25 @@ namespace SqCopyResolution.Services
             {
                 foreach (var comment in comments)
                 {
-                    uri = new Uri(string.Format(CultureInfo.InvariantCulture,
-                        "{0}/api/issues/add_comment",
-                        SonarQubeUrl));
-                    PostToServer(uri, new[] {
-                        new KeyValuePair<string, string>("issue", issueKey),
-                        new KeyValuePair<string, string>("text", comment.HtmlText)
-                    });
+                    PostComment(issueKey, noteToAdd == null ? comment.HtmlText : comment.HtmlText + " " + noteToAdd);
                 }
             }
+            if (comments == null && noteToAdd != null)
+            {
+                PostComment(issueKey, noteToAdd);
+            }
+        }
+
+        private void PostComment(string issueKey, string commentHtmlText)
+        {
+            var uri = new Uri(string.Format(CultureInfo.InvariantCulture,
+                "{0}/api/issues/add_comment",
+                SonarQubeUrl));
+            PostToServer(uri, new[]
+            {
+                new KeyValuePair<string, string>("issue", issueKey),
+                new KeyValuePair<string, string>("text", commentHtmlText)
+            });
         }
 
         private IList<Component> GetProjectComponents(string projectKey, string branchName)


### PR DESCRIPTION
Added an `-ADDNOTE` parameter which causes a comment added to the destination, mentioning the resolution has been copied from elsewhere.